### PR TITLE
README: fix python commands to run the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ You can find the demos in `code/demo/demo2D.py` and
 `code/demo/demo3D.py` files.
 You can run the demos by:
 ```bash
-python -m code.demo.demo2D
-python -m code.demo.demo3D
+python -m ssi.demo.demo2D
+python -m ssi.demo.demo3D
 ```
 
 This should go fast if your GPU is reasonably recent.


### PR DESCRIPTION
The `demo2D.py` and `demo3D.py` scripts live now in `ssi/demo`.